### PR TITLE
docs(doc): add description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 > IMPORTANT This repository is currently experimental.
 
-This repository contains the generated Go packages from this [repository](https://github.com/instill-ai/protobufs) for common protocol buffer types, and the generated gRPC code necessary for interacting with Instill AI's gRPC APIs
+This repository contains the generated Go packages from this [Protobufs](https://github.com/instill-ai/protobufs) for common protocol buffer types, and the generated gRPC code necessary for interacting with Instill AI's gRPC APIs.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# protogen-go
+# Go generated proto packages
+
+> IMPORTANT This repository is currently experimental.
+
+This repository contains the generated Go packages from this [repository](https://github.com/instill-ai/protobufs) for common protocol buffer types, and the generated gRPC code necessary for interacting with Instill AI's gRPC APIs


### PR DESCRIPTION
Because

- enrich more content to README.md to tell users what this repository is

This commit

- add description in README.md
- close #20 
