### PR TITLE
fix: rollback protobufs to 1.30 to prevent plugin break

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.3
-	google.golang.org/protobuf v1.33.0
+	google.golang.org/protobuf v1.30.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -23,5 +23,5 @@ google.golang.org/grpc v1.56.3 h1:8I4C0Yq1EjstUzUJzpcRVbuYA2mODtEmpWiQoN/b2nc=
 google.golang.org/grpc v1.56.3/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=


### PR DESCRIPTION
Because

- The dependency bump produces an incompatibility with the `api-gateway` plugins:
```
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ DEBUG [SERVICE: Executor Plugin] plugin #1 (/usr/local/lib/krakend/plugins/multi-auth.so): plugin.Open("/usr/local/lib/krakend/plugins/multi-auth"): plugin was built with a different version of package google.golang.org/protobuf/internal/detrand
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ DEBUG [SERVICE: Executor Plugin] plugin #2 (/usr/local/lib/krakend/plugins/registry.so): plugin.Open("/usr/local/lib/krakend/plugins/registry"): plugin was built with a different version of package google.golang.org/protobuf/internal/detrand
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ INFO [SERVICE: Executor Plugin] Total plugins loaded: 1
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ INFO [PLUGIN: grpc-proxy-server] Logger loaded
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ DEBUG [SERVICE: Handler Plugin] plugin #1 (/usr/local/lib/krakend/plugins/multi-auth.so): plugin.Open("/usr/local/lib/krakend/plugins/multi-auth.so"): plugin was built with a different version of package google.golang.org/protobuf/internal/detrand (previous failure)
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ DEBUG [SERVICE: Handler Plugin] plugin #2 (/usr/local/lib/krakend/plugins/registry.so): plugin.Open("/usr/local/lib/krakend/plugins/registry.so"): plugin was built with a different version of package google.golang.org/protobuf/internal/detrand (previous failure)
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ INFO [SERVICE: Handler Plugin] Total plugins loaded: 1
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ DEBUG [SERVICE: Modifier Plugin] plugin #0 (/usr/local/lib/krakend/plugins/grpc-proxy.so): plugin: symbol ModifierRegisterer not found in plugin grpc_proxy_plugin
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ DEBUG [SERVICE: Modifier Plugin] plugin #1 (/usr/local/lib/krakend/plugins/multi-auth.so): plugin.Open("/usr/local/lib/krakend/plugins/multi-auth.so"): plugin was built with a different version of package google.golang.org/protobuf/internal/detrand (previous failure)
[KRAKEND] 2024/03/26 - 17:34:08.466 ▶ DEBUG [SERVICE: Modifier Plugin] plugin #2 (/usr/local/lib/krakend/plugins/registry.so): plugin.Open("/usr/local/lib/krakend/plugins/registry.so"): plugin was built with a different version of package google.golang.org/protobuf/internal/detrand (previous failure)
...
[KRAKEND] 2024/03/26 - 17:34:08.532 ▶ DEBUG [PLUGIN: Server] No plugin resgistered as multi-auth
```

This commit

- Sets the package to the highest compatible version
